### PR TITLE
V2/Entity DDD 

### DIFF
--- a/src/main/java/com/seongha/toy/apply/application/ApplyService.java
+++ b/src/main/java/com/seongha/toy/apply/application/ApplyService.java
@@ -25,12 +25,25 @@ public class ApplyService {
 
     public void apply(ApplyCreateReq req) {
         var apply = applyMapper.toEntity(req);
-        var jobPosting = jobPostingRepository.findById(req.jobPostingId()).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공고입니다."));
-        var applicant = individualRepository.findById(req.applicantId()).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 지원자입니다."));
+        var jobPostingId = req.jobPostingId();
+        var applicantId = req.applicantId();
+        validateExist(jobPostingId, applicantId);
 
-        apply.applyStart(jobPosting, applicant);
+        apply.applyStart(jobPostingId, applicantId);
 
         applyRepository.save(apply);
+    }
+
+    private void validateExist(String jobPostingId, String applicantId) {
+        var isExistJobPosting = jobPostingRepository.existsById(jobPostingId);
+        var isExistApplicant = individualRepository.existsById(applicantId);
+
+        if (!isExistJobPosting) {
+            throw new IllegalArgumentException("존재하지 않는 공고입니다.");
+        }
+        if (!isExistApplicant) {
+            throw new IllegalArgumentException("존재하지 않는 지원자입니다.");
+        }
     }
 
     public void changeStatus(ApplyChangeStatusReq req, String applyId) {

--- a/src/main/java/com/seongha/toy/apply/domain/Apply.java
+++ b/src/main/java/com/seongha/toy/apply/domain/Apply.java
@@ -1,17 +1,12 @@
 package com.seongha.toy.apply.domain;
 
 import com.seongha.toy.common.audit.BaseAuditEntity;
-import com.seongha.toy.individual.domain.Individual;
-import com.seongha.toy.jobposting.domain.JobPosting;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,21 +25,17 @@ public class Apply extends BaseAuditEntity {
     @Column(name = "id")
     private String id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_posting_id")
-    private JobPosting jobPosting;
+    private String jobPostingId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "applicant_id")
-    private Individual applicant;
+    private String applicantId;
 
     @Enumerated(EnumType.STRING)
     @Setter
     private ApplicationStatus applicationStatus;
 
-    public void applyStart(JobPosting jobPosting, Individual individual) {
-        this.jobPosting = jobPosting;
-        this.applicant = individual;
+    public void applyStart(String jobPostingId, String individualId) {
+        this.jobPostingId = jobPostingId;
+        this.applicantId = individualId;
         this.applicationStatus = ApplicationStatus.WAITING;
     }
 

--- a/src/main/java/com/seongha/toy/apply/mapper/ApplyMapper.java
+++ b/src/main/java/com/seongha/toy/apply/mapper/ApplyMapper.java
@@ -10,11 +10,10 @@ import org.mapstruct.Mapping;
 public interface ApplyMapper {
 
     @Mapping(ignore = true, target = "id")
-    @Mapping(ignore = true, target = "jobPosting")
-    @Mapping(ignore = true, target = "applicant")
+    @Mapping(ignore = true, target = "jobPostingId")
+    @Mapping(ignore = true, target = "applicantId")
+    @Mapping(ignore = true, target = "applicationStatus")
     Apply toEntity(ApplyCreateReq req);
 
-    @Mapping(source = "jobPosting.id", target = "jobPostingId")
-    @Mapping(source = "applicant.id", target = "applicantId")
     ApplyRes toRes(Apply apply);
 }

--- a/src/main/java/com/seongha/toy/jobposting/domain/JobPosting.java
+++ b/src/main/java/com/seongha/toy/jobposting/domain/JobPosting.java
@@ -1,7 +1,6 @@
 package com.seongha.toy.jobposting.domain;
 
 import com.seongha.toy.common.audit.BaseAuditEntity;
-import com.seongha.toy.company.domain.Company;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -9,10 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -33,9 +29,7 @@ public class JobPosting extends BaseAuditEntity {
     @Column(name = "id")
     private String id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn
-    private Company company;
+    private String companyId;
 
     @Setter
     private String title;
@@ -55,8 +49,8 @@ public class JobPosting extends BaseAuditEntity {
     @Setter
     private PostingStatus postingStatus;
 
-    public void postStart(Company company) {
-        this.company = company;
+    public void postStart(String companyId) {
+        this.companyId = companyId;
         this.postingStatus = PostingStatus.OPEN;
     }
 
@@ -66,8 +60,8 @@ public class JobPosting extends BaseAuditEntity {
         this.postingPeriod = jobPostToEdit.postingPeriod;
     }
 
-    public void validateOwner(Company company) {
-        if (!Objects.equals(this.company.getId(), company.getId())) {
+    public void validateOwner(String companyId) {
+        if (!Objects.equals(this.companyId, companyId)) {
             throw new IllegalArgumentException("공고를 게재한 기업 회원이 아닙니다.");
         }
     }

--- a/src/main/java/com/seongha/toy/jobposting/mapper/JobPostingMapper.java
+++ b/src/main/java/com/seongha/toy/jobposting/mapper/JobPostingMapper.java
@@ -11,15 +11,14 @@ import org.mapstruct.Mapping;
 public interface JobPostingMapper {
 
     @Mapping(ignore = true, target = "id")
-    @Mapping(ignore = true, target = "company")
+    @Mapping(ignore = true, target = "companyId")
     @Mapping(ignore = true, target = "postingStatus")
     JobPosting toEntity(JobPostingPostReq req);
 
     @Mapping(ignore = true, target = "id")
-    @Mapping(ignore = true, target = "company")
+    @Mapping(ignore = true, target = "companyId")
     @Mapping(ignore = true, target = "postingStatus")
     JobPosting toEntity(JobPostingEditReq req);
 
-    @Mapping(source = "company.id", target = "companyId")
     JobPostingRes toRes(JobPosting entity);
 }


### PR DESCRIPTION
### DDD 리팩토링

* DDD에서 Aggregate 개념을 적용하여 Aggregate로 나누고, 간접 참조로 변경
* 이미 V1에서도 패키지별로 Aggregate를 구분했기 때문에 Entity에서 직접 다른 Aggregate Root Entity를 참조하지 않고 간접 참조로만 리팩토링

### Previous Problem(V1)
* Service가 너무 많은 역할을 수행한다.
  * DTO <-> Entity의 Mapper를 사용하여 매핑
  * 비즈니스 로직 수행 (도메인 로직)
  * Repository를 사용하여 Entity CRUD
* Service에서 Client Spec인 DTO에 의존한다.
  * 도메인을 다루는 곳에서 DTO에 의존해도 될까?
* Entity에서 Mapper를 위해 Setter를 사용하고 있다.

### DDD에서 Application Service(Layer)의 역할
-> DDD에서 Application Layer가 하는 역할이 Domain Layer와 Infrastructure Layer를 적절히 호출하는 역할임으로 해당 역할들을 수행하는게 자연스럽다.


### Problem / Refactor Things
* Service에서 Client Spec인 DTO에 의존한다.
  * 도메인을 다루는 곳에서 DTO에 의존해도 될까?
* Entity에서 Mapper를 위해 Setter를 사용하고 있다.



